### PR TITLE
Fix #9 and add time range support for extractions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .mypy_cache
 *.egg-info
+paratex/output/*.csv

--- a/paratex/__main__.py
+++ b/paratex/__main__.py
@@ -1,17 +1,23 @@
 import pandas as pd
-
-from .extractor import extract_attendance, Session
-
+from datetime import date
+from extractor import extract_attendance, Session, fetch_sessions_from_interval
 
 def main():
-    session = extract_attendance(1783)
-    print(session.title)
-    print(as_dataframe(session).head())
+    attendances = []
+    sessions = fetch_sessions_from_interval(date(2011, 10, 15), date(2019, 10, 15))
+    
+    for month in sessions:
+        for session in month:
+            session_data = extract_attendance(session[0])
+            dataframe = session_as_dataframe(session_data)
+            attendances.append(dataframe)
 
+    for dataframe in attendances:
+        dataframe.to_csv(f"output/{dataframe.iloc[1,3]}.csv")
 
 # Intended to be used later on the code. Will leave this here for utility
 # purposes for now.
-def as_dataframe(session: Session):
+def session_as_dataframe(session: Session):
     observations = (
         (name, presence, justification, session.date)
         for name, (presence, justification) in session.attendance.items()
@@ -22,7 +28,6 @@ def as_dataframe(session: Session):
         axis=1
     )
     return df
-
 
 if __name__ == '__main__':
     main()

--- a/paratex/extractor.py
+++ b/paratex/extractor.py
@@ -8,7 +8,6 @@ from bs4 import BeautifulSoup
 from bs4.element import Tag
 import requests
 
-
 @dataclass
 class Session:
     title: str
@@ -53,49 +52,70 @@ def extract_attendance(session_id: int) -> Session:
     return Session(title, date, attendance)
 
 
-def fetch_sessions(period: Optional[Date] = None) -> List[Tuple[str, str]]:
+def fetch_sessions_from_interval(start: Optional[Date] = None, end: Optional[Date] = None) -> List[Tuple[str, str]]:
     '''
     Retrieves a list of given period's session ids and their dates. The period
     comprehends only month/year, so day is ignored. If period is ommited, then
     last available period is used.
     '''
+
+    if end.year < start.year or (end.year == start.year and end.month < start.month):
+        raise ValueError("End date must be bigger than start date")
+
     url = 'http://transparencia.alesc.sc.gov.br/presenca_plenaria.php'
+    query = ''
+    sessions = list()
 
-    if period is not None:
-        url += f'?periodo={period.month}-{period.year}'
+    if start is None and end is None:
+        sessions.append(fetch_session(url))
+    else:
+        for delta_year in range(end.year - start.year):
+            if delta_year == 0:
+                for month in range(start.month, 13):
+                    query = f'?periodo={month:02}-{start.year}'
+                    sessions.append(fetch_session(url + query))
+            elif delta_year == (end.year - start.year):
+                for month in range(1, end.month + 1):
+                    query = f'?periodo={month:02}-{end.year}'
+                    sessions.append(fetch_session(url + query))
+            else:
+                for month in range(1, 13):
+                    query = f'?periodo={month:02}-{start.year + delta_year}'
+                    sessions.append(fetch_session(url + query))
 
+    return sessions
+
+def fetch_session(url: str) -> List[Tuple[str, str]]:
     html = load_html(url)
-
     soup = BeautifulSoup(html, 'html.parser')
-
     table = soup.find('table', {'summary': "Presença dos Deputados"})
-    rows = table.findAll('tr', {'style': "text-align: center;"})
+    
+    if table is not None:
+        rows = table.findAll('tr', {'style': "text-align: center;"})
 
-    date_href_tuples = []
-    for tr in rows:
-        tds = tr.findAll('td')
-        session_date = date_from_str(tds[2].text)
-        session_id = tds[3].find('a').attrs['href'].split('id=')[1]
-        date_href_tuples.append((session_id, session_date))
+        date_href_tuples = []
+        for tr in rows:
+            tds = tr.findAll('td')
+            session_date = date_from_str(tds[2].text)
+            session_id = tds[3].find('a').attrs['href'].split('id=')[1]
+            date_href_tuples.append((session_id, session_date))
 
-    return date_href_tuples
-
+        return date_href_tuples
+    else:
+        return []
 
 def load_html(url: str) -> str:
     return requests.get(url).text
 
-
 def date_from_str(s: str, delim: str = '/') -> Date:
     d, m, y = map(int, s.split(delim))
     return Date(y, m, d)
-
 
 def iter_rows(table: Tag):
     '''Iter through a table's rows.'''
     trs = table.find_all('tr')
     for tr in trs:
         yield tr.find_all('td')
-
 
 def find_session_header(soup: BeautifulSoup) -> Tuple[str, str]:
     '''Retrieves title and date from session page.'''
@@ -106,14 +126,12 @@ def find_session_header(soup: BeautifulSoup) -> Tuple[str, str]:
 def find_attendance_table(soup: BeautifulSoup) -> Tag:
     return soup.find(id='conteudo').table
 
-
 def advance_month(date: Date) -> Date:
     month = date.month
     year = date.year + month // 12
     month = month % 12 + 1
     day = min(date.day, calendar.monthrange(year, month)[1])
     return Date(year, month, day)
-
 
 def get_month_sessions_urls() -> List[str]:
     dt = Date(2011, 4, 1)

--- a/paratex/extractor.py
+++ b/paratex/extractor.py
@@ -56,8 +56,11 @@ def fetch_sessions_from_interval(start: Optional[Date] = None, end: Optional[Dat
     '''
     Retrieves a list of given period's session ids and their dates. The period
     comprehends only month/year, so day is ignored. If period is ommited, then
-    last available period is used.
+    last available period is used. If end is ommited use current date as end.
     '''
+
+    if end is None and start is not None:
+        end = Date.today()
 
     if end.year < start.year or (end.year == start.year and end.month < start.month):
         raise ValueError("End date must be bigger than start date")


### PR DESCRIPTION
Fix #9 by creating CSV files using panda's dataframe.to_csv. The files will be created in runtime at paratex/output and ignored by git. For now it creates a separated file for each session, in future we should add support for creating a big CSV file with all the attendances extraced.

For time range, the function expects two Date objects, start and end. If start and end are ommited last month's data will be used. If just end is ommited the end time will be the current date. If start is bigger than end a exception is raised.