### PR TITLE
Rely on pyproject.toml to config check/format tools

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,5 +27,5 @@ jobs:
     -
       name: Run tests
       run: |
-        poetry run isort --check-only --diff --line-width=100 .
-        poetry run black --check --diff --line-length=100 .
+        poetry run isort --check-only --diff .
+        poetry run black --check --diff .


### PR DESCRIPTION
Instead of CI run tool commands with specific flags, we will rely on `pyproject.toml` configs.

Should (finally) fix the CI issues.